### PR TITLE
Allow for : in passwords and messages.

### DIFF
--- a/ejabberd_external_auth.php
+++ b/ejabberd_external_auth.php
@@ -138,7 +138,7 @@ abstract class EjabberdExternalAuth {
     }
 
     final private function parseMessage($message) {
-        $message = explode(':', $message);
+        $message = explode(':', $message, 4);
         if (count($message) < 3) {
             throw new UnexpectedValueException('Message is too short: ' . join(':', $message));
         }


### PR DESCRIPTION
A user reported his password wouldn't work, apparently he used a : inside his password. With no limit on explode(), it was shortened to the first few characters. -crubb
