### PR TITLE
Updated ejabberd_external_auth.php

### DIFF
--- a/ejabberd_external_auth.php
+++ b/ejabberd_external_auth.php
@@ -122,7 +122,7 @@ abstract class EjabberdExternalAuth {
     }
 
     final private function read() {
-        $length = fgets($this->stdin, 3);
+        $length = stream_get_line($this->stdin, 65535);
 
         if (feof($this->stdin)) {
             throw new RuntimeException('Pipe broken');


### PR DESCRIPTION
### Reason:
http://php.net/manual/en/function.stream-get-line.php
```
function stream_get_line is nearly identical to fgets() except in that it allows end of line delimiters other than the standard \n, \r, and \r\n, and does not return the delimiter itself.
65535 may be decreased
```